### PR TITLE
Fix broken links

### DIFF
--- a/docs/data/publishing.md
+++ b/docs/data/publishing.md
@@ -9,11 +9,9 @@ author_2:
 
 If you would like to publish your data collection in 4TU.ResearchData or another data repository, it is advisable that you discuss the publishing process, including the reuse and [citation](https://www.tudelft.nl/en/library/research-data-management/r/publish/cite-your-data) of the original datasets and appropriate [licensing](https://data.4tu.nl/info/en/use/publish-cite/upload-your-data-in-our-data-repository/licencing) options with your faculty [Data Steward](https://www.tudelft.nl/library/research-data-management/r/support/data-stewardship/contact). 
 
-- To learn more about research data management, you can participate in an introductory workshop on [Research Data Management](https://www.tudelft.nl/en/library/research-data-management/r/training-events/training-for-researchers/research-data-management-101) offered by TU Delft, or review materials from online resources. 
+- To learn more about research data management, you can participate in an introductory workshop on [Research Data Management](https://www.tudelft.nl/en/library/research-data-management/r/training-events/training-for-researchers/research-data-management-101) offered by TU Delft, or review materials from online resources.
 
-- [Managing and Sharing Research Data](https://www.fosteropenscience.eu/learning/managing-and-sharing-research-data/) course from [FOSTER](https://www.fosteropenscience.eu/) - e-learning platform that brings together the training resources addressed to those who need to develop strategies and skills for implementing Open Science practices in their daily workflows 
-
-- See a videos on [best practices](https://ukdataservice.ac.uk/learning-hub/research-data-management/format-your-data/organising/) on organising data files from [UK Data Service](https://ukdataservice.ac.uk/) 
+- See a videos on [best practices](https://ukdataservice.ac.uk/learning-hub/research-data-management/format-your-data/organising/) on organising data files from [UK Data Service](https://ukdataservice.ac.uk/).
 
 - See a [General guide](https://mediacentral.princeton.edu/media/How+to+Prepare+Data+for+PublicationA+An+Overview/1_v0who3u4) prepared by [Princeton Research Data Service](https://researchdata.princeton.edu/) on how to prepare data for publication as well more detailed videos on:  
     - [READMEs and codebooks ](https://mediacentral.princeton.edu/media/Preparing+Data+for+PublicationA+Readmes+and+Documentation/1_sknb0yn3)

--- a/docs/software/software_management_plan.md
+++ b/docs/software/software_management_plan.md
@@ -15,7 +15,7 @@ The initiative resulted in the publication of the [**Practical guide to Software
 
 ## Resources for software development
 
-* [Understanding the Phases of the Software Development Life Cycle](https://harness.io/blog/software-development-life-cycle/)
+* [Understanding the Phases of the Software Development Life Cycle](https://resources.github.com/software-development/what-is-sdlc/)
 
 * [Software Management from AcqNotes](https://acqnotes.com/acqnote/careerfields/software-management-overview)
 


### PR DESCRIPTION
Changes:

1) Propose to remove fosteropenscience.eu e-learning platform. The links to this platform have been failing for a while, so it was removed from the list in `software_management_plan.md`.
2) Another broken link was fixed.