### PR TITLE
Update actions/checkout from v3 to v4

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -10,7 +10,7 @@ jobs:
   linkChecker:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Link Checker
         uses: lycheeverse/lychee-action@v1.9.3

--- a/.github/workflows/links_fail_fast.yml
+++ b/.github/workflows/links_fail_fast.yml
@@ -15,7 +15,7 @@ jobs:
   linkChecker:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Link Checker
         uses: lycheeverse/lychee-action@v1.9.3


### PR DESCRIPTION
The actions/checkout@v3 action uses Node.js 16, which is deprecated. Updated to actions/checkout@v4 to ensure compatibility with Node.js 20.