### PR TITLE
#41 Add GitHub star button

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -33,7 +33,11 @@ website:
   repo-actions: [issue]
   page-navigation: true
   page-footer:
-    left: "By TU Delft Digital Competence Centre. Content on this site is licensed under a [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) license. "
+    left: By TU Delft Digital Competence Centre. Content on this site is licensed under a [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) license.
+    right: 
+          If you find this content useful, please consider giving us a star on GitHub.
+          <script async defer src="https://buttons.github.io/buttons.js"></script>
+          <a class="github-button" href="https://github.com/TU-Delft-DCC/TU-Delft-DCC.github.io" data-icon="star" data-size="small" data-show-count="false" aria-label="Star TU-Delft-DCC/TU-Delft-DCC.github.io on GitHub">Star</a>   
   bread-crumbs: true # Breadcrumbs in Quarto websites are a type of secondary navigation that shows the user's current location within the site hierarchy
   navbar:
     logo: docs/img/logo.png


### PR DESCRIPTION
Added a GitHub star button to `_quarto.yaml`. To ensure it is visible on every page, I placed it on the right side of the footer. Leave a comment if further adjustments are needed or accept the PR.