### PR TITLE
#163 #166 Update FAIR checklist and FAIR software introduction documentation

### DIFF
--- a/docs/software/checklist.md
+++ b/docs/software/checklist.md
@@ -2,7 +2,7 @@
 # Insert this YAML header (including the opening and closing ---) at the beginning of the document and fill it out accordingly
 
 # We use this key to indicate the last reviewed date [manual entry, use MM/DD/YYYY]
-#date:
+date: 11/12/2024
 
 # We use this key to indicate the last modified date [automatic entry]
 date-modified: last-modified
@@ -21,36 +21,20 @@ author_1: Maurits Kok
 author_2: Elviss Dvinskis
 
 # Maintainers of the document, will not be parsed [manual entry]
-maintainer_1:
+maintainer_1: Elviss Dvinskis
 maintainer_2:
 
 # To whom reach out regarding the document, will not be parsed [manual entry]
-corresponding:
+corresponding: Elviss Dvinskis
 
 # Meaningful keywords, newline separated [manual entry]
 categories: 
- - 
- - 
+ - FAIR
+ - Checklist
 
 ---
 
-The goal of the FAIR principles is to improve research transparency, reproducibility and reusability. To achieve this, your research needs to be described through metadata, should be open for inspection, well-documented, and well structured. This ensures that it can be replicated, expanded upon, merged, reinterpreted, or reimplemented. The acronym FAIR stands for:
-
-- **F**indable: Your research software can be easily found (i.e. has rich metadata, unique identifiers).
-- **A**ccessible: Once found, it can be accessed, ideally through well-defined and open protocols.
-- **I**nteroperable: Your research is compatible with other datasets, tools, and workflows, allowing for integration and reuse across various applications and fields.
-- **R**eusable: The ultimate goal is that your research outputs can be reused in different contexts. This requires comprehensive documentation, clear licensing, and a modular structure.
-
-While originally targetting data management, the FAIR for Research Software (FAIR4RS) extends these principles to research software, which, unlike data, is executable and evolves over time. Ensuring the findability of software involves metadata, identifiers, and version control systems, while accessibility includes guidelines for obtaining, installing, and running the software. Interoperability involves adherence to community-driven standards or protocols, and reusability requires detailed documentation and user guides to effectively apply the software in new research projects.
-
-:::{.callout-note}
-## **Further reading**
-
-- [FAIR Guiding Principles for scientific data management and stewardship to research software](https://zenodo.org/records/6623556)
-- [FAIR4RS community in Zenodo](https://zenodo.org/communities/fair4rs/records?q=&l=list&p=1&s=10&sort=newest)
-- [FAIR Software Checklist](https://fair-software.nl/) - five recommendations for FAIR (scientific) software 
-:::
-
+This checklist provides a set of recommendations for FAIR software. It outlines best practices and guidelines to ensure the quality, reproducibility, and sustainability of software projects. The checklist covers various aspects, such as version control, documentation, testing, licensing, and collaboration, providing a comprehensive framework for improving your software development process.
 
 ## Checklist
 

--- a/docs/software/fair.md
+++ b/docs/software/fair.md
@@ -2,7 +2,7 @@
 # Insert this YAML header (including the opening and closing ---) at the beginning of the document and fill it out accordingly
 
 # We use this key to indicate the last reviewed date [manual entry, use MM/DD/YYYY]
-#date:
+date: 11/13/2024
 
 # We use this key to indicate the last modified date [automatic entry]
 date-modified: last-modified
@@ -17,20 +17,35 @@ language:
 title: FAIR Software
 
 # Authors of the document, will not be parsed [manual entry]
-author_1:
-author_2:
+author_1: Maurits Kok
+author_2: Elviss Dvinskis
 
 # Maintainers of the document, will not be parsed [manual entry]
-maintainer_1:
+maintainer_1: Elviss Dvinskis
 maintainer_2:
 
 # To whom reach out regarding the document, will not be parsed [manual entry]
-corresponding:
+corresponding: Elviss Dvinskis
 
 # Meaningful keywords, newline separated [manual entry]
 categories: 
- - 
- - 
+ - FAIR
 
 ---
-🏗️ Under construction
+
+The goal of the FAIR principles is to improve research transparency, reproducibility and reusability. To achieve this, your research needs to be described through metadata, should be open for inspection, well-documented, and well structured. This ensures that it can be replicated, expanded upon, merged, reinterpreted, or reimplemented. The acronym FAIR stands for:
+
+- **F**indable: Your research software can be easily found (i.e. has rich metadata, unique identifiers).
+- **A**ccessible: Once found, it can be accessed, ideally through well-defined and open protocols.
+- **I**nteroperable: Your research is compatible with other datasets, tools, and workflows, allowing for integration and reuse across various applications and fields.
+- **R**eusable: The ultimate goal is that your research outputs can be reused in different contexts. This requires comprehensive documentation, clear licensing, and a modular structure.
+
+While originally targetting data management, the FAIR for Research Software (FAIR4RS) extends these principles to research software, which, unlike data, is executable and evolves over time. Ensuring the findability of software involves metadata, identifiers, and version control systems, while accessibility includes guidelines for obtaining, installing, and running the software. Interoperability involves adherence to community-driven standards or protocols, and reusability requires detailed documentation and user guides to effectively apply the software in new research projects.
+
+:::{.callout-note}
+## **Further reading**
+
+- [FAIR Guiding Principles for scientific data management and stewardship to research software](https://zenodo.org/records/6623556)
+- [FAIR4RS community in Zenodo](https://zenodo.org/communities/fair4rs/records?q=&l=list&p=1&s=10&sort=newest)
+- [FAIR Software Checklist](https://fair-software.nl/) - five recommendations for FAIR (scientific) software 
+:::


### PR DESCRIPTION
The checklist and project cards were recently reviewed and updated.

Addresses:

- #163 
- #166 

Changes:

- Moved the introduction about FAIR software from `docs/software/checklist.md` to `docs/software/checklist.md`.
- Added a short paragraph for the checklist in `docs/software/checklist.md`.
- Filled in the metadata fields and added myself as a maintainer and corresponding maintainer.