### PR TITLE
Update link_checker.yml

### DIFF
--- a/.github/workflows/link_checker.yml
+++ b/.github/workflows/link_checker.yml
@@ -4,9 +4,11 @@ on:
   push:
     branches:
       - main
-  pull_request:    
+      - develop
+  pull_request:
     branches:
       - main
+      - develop
 
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
Add `develop` branch to the list of triggers for both push and pull_request events in the Link Checker GitHub Actions workflow.

This change ensures that the Link Checker runs on:
- Direct pushes to main and develop branches
- Pull requests targeting main and develop branches