### PR TITLE
Update uv package management for clearer guidance

### DIFF
--- a/docs/software/development_workflow/envs_dependencies/python_envs_dependencies.md
+++ b/docs/software/development_workflow/envs_dependencies/python_envs_dependencies.md
@@ -186,7 +186,7 @@ Besides the aforementioned tools, `uv` is becoming increasingly adopted because 
 
 In practice, `uv` can replace `pip`, and often `virtualenv`, while also covering much of what tools like Poetry are used for but with a **clearer separation of responsibilities**. 
 
-::: {.callout-tip icon="false"}
+::: {.callout-tip appearance="simple" icon="false"}
 ## {{< fa lightbulb >}} `uv` excels at Python-level dependencies
 
 - `uv` does not replace system or distribution-level package managers (such as `conda`, `apt`, or `brew`)
@@ -261,7 +261,7 @@ uv sync
 
 This installs exactly what is declared in `pyproject.toml` and `uv.lock`
 
-::: {.callout-tip icon="false"}
+::: {.callout-tip appearance="simple" icon="false"}
 ## {{< fa lightbulb >}} Some useful commands to make the most out of `uv`
 
 - `uv add --dev <package>`: add a development dependency


### PR DESCRIPTION
I updated the section in Python package management about `uv` after I had some more hands-on experience with it myself, and understanding where it can be especially useful, (which is managing Python-dependecies in a project repo and separation of tasks)

- Explained how to use `uv` within a `conda` or a `venv`, since I find either of these 2 options to be the safest
- Corrected overstatements about `uv` "replacing" `conda` or system package managers like `brew` or `apt`
- Added guidence on how to migrate an existing `requirements.txt` file to a new `uv` based project