### PR TITLE
Cache lychee results in link checker workflow

### DIFF
--- a/.github/workflows/link_checker.yml
+++ b/.github/workflows/link_checker.yml
@@ -36,6 +36,14 @@ jobs:
       - name: Build Quarto site
         run: quarto render  # Build the Quarto book to generate the latest content
 
+      - name: Restore lychee cache
+        id: restore-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: .lycheecache
+          key: cache-lychee-${{ github.sha }}
+          restore-keys: cache-lychee-
+        
       - name: Link Checker
         uses: lycheeverse/lychee-action@v2
         with:
@@ -47,3 +55,10 @@ jobs:
           fail: true  # Fail the job if any links are broken
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Save lychee cache
+        uses: actions/cache/save@v4
+        if: always()
+        with:
+          path: .lycheecache
+          key: ${{ steps.restore-cache.outputs.cache-primary-key }}

--- a/lychee.toml
+++ b/lychee.toml
@@ -19,7 +19,7 @@ no_progress = false
 cache = true
 
 # Discard all cached requests older than this duration.
-max_cache_age = "1h"
+max_cache_age = "24h"
 
 #############################  Runtime  #############################
 


### PR DESCRIPTION
Add restore/save cache steps to .github/workflows/link_checker.yml using actions/cache/restore@v4 and actions/cache/save@v4 to persist .lycheecache between runs (primary key uses github.sha, with a fallback restore key). Also increase lychee.toml max_cache_age from 1h to 24h so cached responses are retained longer, reducing repeated network calls and speeding up link checks.