### PR TITLE
Upgrade actions/cache to v5 in workflows

### DIFF
--- a/.github/workflows/link_checker.yml
+++ b/.github/workflows/link_checker.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Restore lychee cache
         id: restore-cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: .lycheecache
           key: cache-lychee-${{ github.sha }}
@@ -57,7 +57,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Save lychee cache
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         if: always()
         with:
           path: .lycheecache

--- a/.github/workflows/scheduled_link_checker.yml
+++ b/.github/workflows/scheduled_link_checker.yml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Restore lychee cache
         id: restore-cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: .lycheecache
           key: cache-lychee-${{ github.sha }}
@@ -41,7 +41,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Save lychee cache
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         if: always()
         with:
           path: .lycheecache


### PR DESCRIPTION
Update actions/cache from v4 to v5 in .github/workflows/link_checker.yml and .github/workflows/scheduled_link_checker.yml for both the Restore lychee cache and Save lychee cache steps. Caching behavior (path .lycheecache and cache key) remains unchanged; this updates workflows to the latest cache action version.