### PR TITLE
Add a small section about Ruff and automating code quality

### DIFF
--- a/docs/software/automation/github_ci_cd.md
+++ b/docs/software/automation/github_ci_cd.md
@@ -96,7 +96,7 @@ ruff format --check .
 
 ::: {.callout-note appearance="simple" icon="false" collapse="true"}
 ## {{< fa circle-check >}} Running Ruff with Github Actions
-A minimal worflow for running Ruff for pushes to develop and for pull requests targeting develop looks like this:
+A minimal workflow for running Ruff for pushes to develop and for pull requests targeting develop looks like this:
 
 
 Create `.github/workflows/ruff.yml`

--- a/docs/software/automation/github_ci_cd.md
+++ b/docs/software/automation/github_ci_cd.md
@@ -134,7 +134,7 @@ jobs:
 ```
 :::
 
-Ruff can be configured further to control which linting rules are enabled, which files or directories are excluded, formatting behavior, and etc. See the [Ruff documentation](https://docs.astral.sh/ruff/configuration/)
+Ruff can be configured further to control which linting rules are enabled, which files or directories are excluded, formatting behavior, and other settings. See the [Ruff documentation](https://docs.astral.sh/ruff/configuration/)
 
 ### Automating testing
 A common usecase of automation is to trigger automatic testing when pushing changes and creating pull requests.

--- a/docs/software/automation/github_ci_cd.md
+++ b/docs/software/automation/github_ci_cd.md
@@ -74,7 +74,7 @@ Ruff is a Python linter and code formatter. It can replace some commonly used to
 
 For example, a minimal configuration in `pyproject.toml` could look like:
 
-```yaml
+```toml
 [tool.ruff] 
 line-length = 88 
 
@@ -101,7 +101,7 @@ A minimal worflow for running Ruff for pushes to develop and for pull requests t
 
 Create `.github/workflows/ruff.yml`
 
-```yaml
+```toml
 name: Ruff 
 
 on: 

--- a/docs/software/automation/github_ci_cd.md
+++ b/docs/software/automation/github_ci_cd.md
@@ -95,7 +95,7 @@ ruff format --check .
 ```
 
 ::: {.callout-note appearance="simple" icon="false" collapse="true"}
-## {{< fa circle-check >}} Running Ruff with Github actions
+## {{< fa circle-check >}} Running Ruff with Github Actions
 A minimal worflow for running Ruff for pushes to develop and for pull requests targeting develop looks like this:
 
 

--- a/docs/software/automation/github_ci_cd.md
+++ b/docs/software/automation/github_ci_cd.md
@@ -64,6 +64,76 @@ categories:
 - Test your workflow in a separate branch to avoid committing many small changes during debugging of the workflow.
 :::
 
+### Automating code quality checks
+Code quality tools can be integrated into a GitHub actions workflow to automatically check code whenever changes are pushed or a pull request is opened. this helps maintain a consistent coding style and catch common scripting errors before changes are merged.
+
+#### Ruff
+Ruff is a Python linter and code formatter. It can replace some commonly used tools, including Flake8 and Black depending on how you configure it. You can configure your Ruff workflow either in your project's `pyproject.toml` file or `ruff.toml`.
+
+For example, a minimal configuration in `pyproject.toml` could look like:
+
+```yaml
+[tool.ruff] 
+line-length = 88 
+
+[tool.ruff.lint] 
+select = ["E", "F", "I"]
+```
+
+You can run Ruff locally with:
+
+```bash
+ruff check .
+```
+
+and check whether files are correctly formatted with:
+
+```bash
+ruff format --check .
+```
+
+::: {.callout-note appearance="simple" icon="false" collapse="true"}
+## {{< fa circle-check >}} Running Ruff with Github actions
+A minimal worflow for running Ruff for pushes to develop and for pull requests targeting develop looks like this:
+
+
+Create `.github/workflows/ruff.yml`
+
+```yaml
+name: Ruff 
+
+on: 
+  push: 
+    branches: 
+      - develop
+  pull_request:
+    branches: 
+      - develop
+  workflow_dispatch: 
+  
+jobs: 
+  ruff: 
+    runs-on: ubuntu-latest 
+    
+    steps: 
+      - name: Check out repository 
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+
+      - name: Install Ruff
+        run: pip install ruff
+
+      - name: Run Ruff
+        run: ruff check --output-format=github .
+```
+:::
+
+Ruff can be configured further to control which linting rules are enabled, which files or directories are excluded, formatting behavior, and etc. See the [Ruff documentation](https://docs.astral.sh/ruff/configuration/)
+
 ### Automating testing
 A common usecase of automation is to trigger automatic testing when pushing changes and creating pull requests.
 

--- a/docs/software/automation/github_ci_cd.md
+++ b/docs/software/automation/github_ci_cd.md
@@ -7,7 +7,7 @@ date: 2025-08-22
 
 # We use this key to indicate the last modified date [manual entry, use YYYY-MM-DD]
 # Uncomment and populate the next line accordingly
-date-modified: 2025-10-28
+date-modified: 2026-08-21
 
 # Do not modify
 lang: en
@@ -28,6 +28,7 @@ hide-description: true
 # Uncomment and populate the next lines accordingly
 author_1: Maurits Kok
 author_2: Elviss Dvinskis
+author_3: Aysun Urhan
 
 # Maintainers of the document, will not be parsed [manual entry]
 # Uncomment and populate the next lines accordingly
@@ -45,6 +46,7 @@ categories:
   - Automation
   - GitHub
   - CI/CD
+  - Ruff
 
 ---
 


### PR DESCRIPTION
Added a new section on using Ruff with GitHub Actions to the CI/CD guide. It's an introduction with a minimal Ruff workflow file, explaining how to configure Ruff through pyproject.toml, and shows how to run linting checks locally and in CI. 

I place the section before automated testing to separate code quality checks from behavioural testing, so the content flow as: code quality -> testing -> documentation -> packaging/deployment.

Closes #444 
